### PR TITLE
실행환경 및 방법수정 [필요 패키지 추가, rm 미지원항목추가]

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ### 실행 환경 및 방법
 
-* python3.x
+* python3.x (python 3.10 미지원)
 * requirements
 ```
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy==1.20.1
+matplotlib==3.5.3


### PR DESCRIPTION
1. numpy 1.20.1 버전 설치시 아래와 같은 오류 나타남(python 3.10, window 환경)  
  TypeError: CCompiler_spawn() got an unexpected keyword argument 'env' [end of output] note: This error originates from a subprocess, and is likely not a problem with pip. error: metadata-generation-failed  
  그에 따라 python 3.10 미지원이라는 문구 추가
2. bundle_processor.py 실행하기 위한 필요 패키지 추가(matplotlib)